### PR TITLE
Added DrawableRectangle and DrawableRoundRectangle

### DIFF
--- a/src/drawables/drawable-rectangle.ts
+++ b/src/drawables/drawable-rectangle.ts
@@ -1,0 +1,23 @@
+// Copyright Dirk Lemstra https://github.com/dlemstra/magick-wasm.
+// Licensed under the Apache License, Version 2.0.
+
+import { IDrawable } from "./drawable";
+import { IDrawingWand } from "./drawing-wand";
+
+export class DrawableRectangle implements IDrawable {
+    private readonly _upperLeftX: number;
+    private readonly _upperLeftY: number;
+    private readonly _lowerRightX: number;
+    private readonly _lowerRightY: number;
+
+    constructor(upperLeftX: number, upperLeftY: number, lowerRightX: number, lowerRightY: number) {
+        this._upperLeftX = upperLeftX;
+        this._upperLeftY = upperLeftY;
+        this._lowerRightX = lowerRightX;
+        this._lowerRightY = lowerRightY;
+    }
+
+    draw(wand: IDrawingWand): void {
+        wand.rectangle(this._upperLeftX, this._upperLeftY, this._lowerRightX, this._lowerRightY);
+    }
+}

--- a/src/drawables/drawable-round-rectangle.ts
+++ b/src/drawables/drawable-round-rectangle.ts
@@ -1,0 +1,27 @@
+// Copyright Dirk Lemstra https://github.com/dlemstra/magick-wasm.
+// Licensed under the Apache License, Version 2.0.
+
+import { IDrawable } from "./drawable";
+import { IDrawingWand } from "./drawing-wand";
+
+export class DrawableRoundRectangle implements IDrawable {
+    private readonly _upperLeftX: number;
+    private readonly _upperLeftY: number;
+    private readonly _lowerRightX: number;
+    private readonly _lowerRightY: number;
+    private readonly _cornerWidth: number;
+    private readonly _cornerHeight: number;
+
+    constructor(upperLeftX: number, upperLeftY: number, lowerRightX: number, lowerRightY: number, cornerWidth: number, cornerHeight: number) {
+        this._upperLeftX = upperLeftX;
+        this._upperLeftY = upperLeftY;
+        this._lowerRightX = lowerRightX;
+        this._lowerRightY = lowerRightY;
+        this._cornerWidth = cornerWidth;
+        this._cornerHeight = cornerHeight;
+    }
+
+    draw(wand: IDrawingWand): void {
+        wand.roundRectangle(this._upperLeftX, this._upperLeftY, this._lowerRightX, this._lowerRightY, this._cornerWidth, this._cornerHeight);
+    }
+}

--- a/src/drawables/drawing-wand.ts
+++ b/src/drawables/drawing-wand.ts
@@ -19,6 +19,8 @@ export interface IDrawingWand extends INativeInstance {
     fillOpacity(value: number): void;
     font(family: string): void;
     fontPointSize(value: number): void;
+    rectangle(upperLeftX: number, upperLeftY: number, lowerRightX: number, lowerRightY: number): void;
+    roundRectangle(upperLeftX: number, upperLeftY: number, lowerRightX: number, lowerRightY: number, cornerWidth: number, cornerHeight: number): void;
     text(x: number, y: number, value: string): void;
 }
 
@@ -73,6 +75,18 @@ export class DrawingWand extends NativeInstance implements IDrawingWand {
     fontPointSize(value: number): void {
         Exception.usePointer(exception => {
             ImageMagick._api._DrawingWand_FontPointSize(this._instance, value, exception);
+        });
+    }
+
+    rectangle(upperLeftX: number, upperLeftY: number, lowerRightX: number, lowerRightY: number): void {
+        Exception.usePointer(exception => {
+            ImageMagick._api._DrawingWand_Rectangle(this._instance, upperLeftX, upperLeftY, lowerRightX, lowerRightY, exception);
+        });
+    }
+
+    roundRectangle(upperLeftX: number, upperLeftY: number, lowerRightX: number, lowerRightY: number, cornerWidth: number, cornerHeight: number): void {
+        Exception.usePointer(exception => {
+            ImageMagick._api._DrawingWand_RoundRectangle(this._instance, upperLeftX, upperLeftY, lowerRightX, lowerRightY, cornerWidth, cornerHeight, exception);
         });
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@ export * from './drawables/drawable-fill-color';
 export * from './drawables/drawable-fill-opacity';
 export * from './drawables/drawable-font-point-size';
 export * from './drawables/drawable-font';
+export * from './drawables/drawable-rectangle';
+export * from './drawables/drawable-round-rectangle';
 export * from './drawables/drawable-text';
 export * from './drawables/drawable';
 export * from './drawables/drawing-wand';

--- a/tests/drawables/drawable-rectangle.spec.ts
+++ b/tests/drawables/drawable-rectangle.spec.ts
@@ -1,0 +1,39 @@
+// Copyright Dirk Lemstra https://github.com/dlemstra/magick-wasm.
+// Licensed under the Apache License, Version 2.0.
+
+import { DrawableRectangle } from '../../src/drawables/drawable-rectangle';
+import { DrawableFillColor } from '../../src/drawables/drawable-fill-color';
+import { ImageMagick } from '../../src/image-magick';
+import { IMagickImage, MagickImage } from '../../src/magick-image';
+import { MagickColors } from '../../src/magick-colors';
+import '../custom-matcher';
+
+let image: IMagickImage;
+
+beforeEach(() => {
+    ImageMagick._api = global.native;
+    image = MagickImage.create();
+    image.read(MagickColors.White, 5, 4);
+});
+
+afterEach(() => {
+    image.dispose();
+});
+
+describe('DrawableRectangle', () => {
+    it('should draw a rectangle', () => {
+        image.draw([
+            new DrawableFillColor(MagickColors.Green),
+            new DrawableRectangle(1, 1, 3, 2),
+        ]);
+
+        // Check a corner
+        expect(image).toHavePixelWithColor(0, 0, '#ffffffff');
+        expect(image).toHavePixelWithColor(0, 3, '#ffffffff');
+        expect(image).toHavePixelWithColor(3, 0, '#ffffffff');
+
+        // Check the inside
+        expect(image).toHavePixelWithColor(1, 1, '#008000ff');
+        expect(image).toHavePixelWithColor(3, 2, '#008000ff');
+    });
+});

--- a/tests/drawables/drawable-round-rectangle.spec.ts
+++ b/tests/drawables/drawable-round-rectangle.spec.ts
@@ -1,0 +1,39 @@
+// Copyright Dirk Lemstra https://github.com/dlemstra/magick-wasm.
+// Licensed under the Apache License, Version 2.0.
+
+import { DrawableRoundRectangle } from '../../src/drawables/drawable-round-rectangle';
+import { DrawableFillColor } from '../../src/drawables/drawable-fill-color';
+import { ImageMagick } from '../../src/image-magick';
+import { IMagickImage, MagickImage } from '../../src/magick-image';
+import { MagickColors } from '../../src/magick-colors';
+import '../custom-matcher';
+
+let image: IMagickImage;
+
+beforeEach(() => {
+    ImageMagick._api = global.native;
+    image = MagickImage.create();
+    image.read(MagickColors.White, 12, 12);
+});
+
+afterEach(() => {
+    image.dispose();
+});
+
+describe('DrawableRoundRectangle', () => {
+    it('should draw a rounded rectangle', () => {
+        image.draw([
+            new DrawableFillColor(MagickColors.Green),
+            new DrawableRoundRectangle(0, 0, 11, 11, 5, 5),
+        ]);
+
+        // Check a corner
+        expect(image).toHavePixelWithColor(0, 0, '#ffffffff');
+        expect(image).toHavePixelWithColor(0, 1, '#ffffffff');
+        expect(image).toHavePixelWithColor(1, 0, '#ffffffff');
+
+        // Check an edge and inside
+        expect(image).toHavePixelWithColor(6, 0, '#008000ff');
+        expect(image).toHavePixelWithColor(6, 6, '#008000ff');
+    });
+});


### PR DESCRIPTION
This adds `DrawableRectangle` and `DrawableRoundRectangle` as wand drawables.

The rectangle could technically be done currently with extra images and composites, but I couldn't figure out an easy way to do the rounded version without calling out to the native library.