### PR TITLE
Add WASM file to package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
             "import": "./dist/index.mjs",
             "require": "./dist/index.umd.js",
             "types": "./dist/index.d.ts"
-        }
+        },
+        "./magick.wasm": "./dist/magick.wasm"
     },
     "main": "./dist/index.umd.js",
     "module": "./dist/index.mjs",


### PR DESCRIPTION
Separately exporting the WASM file removes the need to copy the WASM file to a user's project.

E.g. Vite will automatically include it in your bundle when used as such:
```js
import { initializeImageMagick } from '@imagemagick/magick-wasm';

initializeImageMagick(
  new URL('@imagemagick/magick-wasm/magick.wasm', import.meta.url).href
).then(
  /* ... */
);
```