### PR TITLE
add drawable kerning

### DIFF
--- a/src/drawables/drawable-kerning.ts
+++ b/src/drawables/drawable-kerning.ts
@@ -1,0 +1,17 @@
+// Copyright Dirk Lemstra https://github.com/dlemstra/magick-wasm.
+// Licensed under the Apache License, Version 2.0.
+
+import { IDrawable } from './drawable';
+import { IDrawingWand } from './drawing-wand';
+
+export class DrawableKerning implements IDrawable {
+    private readonly _kerning: number;
+
+    constructor(kerning: number) {
+        this._kerning = kerning;
+    }
+
+    draw(wand: IDrawingWand): void {
+        wand.kerning(this._kerning);
+    }
+}

--- a/src/drawables/drawing-wand.ts
+++ b/src/drawables/drawing-wand.ts
@@ -21,8 +21,8 @@ export interface IDrawingWand extends IDisposable {
     fillOpacity(value: number): void;
     font(family: string): void;
     fontPointSize(value: number): void;
-    kerning(value: number): void;
     gravity(value: Gravity): void;
+    kerning(value: number): void;
     rectangle(upperLeftX: number, upperLeftY: number, lowerRightX: number, lowerRightY: number): void;
     roundRectangle(upperLeftX: number, upperLeftY: number, lowerRightX: number, lowerRightY: number, cornerWidth: number, cornerHeight: number): void;
     text(x: number, y: number, value: string): void;
@@ -82,15 +82,15 @@ export class DrawingWand extends NativeInstance implements IDrawingWand {
         });
     }
 
-    kerning(value: number): void {
-        Exception.usePointer(exception => {
-            ImageMagick._api._DrawingWand_TextKerning(this._instance, value, exception);
-        });
-    }
-
     gravity(value: Gravity): void {
         Exception.usePointer(exception => {
             ImageMagick._api._DrawingWand_Gravity(this._instance, value, exception);
+        });
+    }
+
+    kerning(value: number): void {
+        Exception.usePointer(exception => {
+            ImageMagick._api._DrawingWand_TextKerning(this._instance, value, exception);
         });
     }
 

--- a/src/drawables/drawing-wand.ts
+++ b/src/drawables/drawing-wand.ts
@@ -21,6 +21,7 @@ export interface IDrawingWand extends IDisposable {
     fillOpacity(value: number): void;
     font(family: string): void;
     fontPointSize(value: number): void;
+    kerning(value: number): void;
     gravity(value: Gravity): void;
     rectangle(upperLeftX: number, upperLeftY: number, lowerRightX: number, lowerRightY: number): void;
     roundRectangle(upperLeftX: number, upperLeftY: number, lowerRightX: number, lowerRightY: number, cornerWidth: number, cornerHeight: number): void;
@@ -78,6 +79,12 @@ export class DrawingWand extends NativeInstance implements IDrawingWand {
     fontPointSize(value: number): void {
         Exception.usePointer(exception => {
             ImageMagick._api._DrawingWand_FontPointSize(this._instance, value, exception);
+        });
+    }
+
+    kerning(value: number): void {
+        Exception.usePointer(exception => {
+            ImageMagick._api._DrawingWand_TextKerning(this._instance, value, exception);
         });
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export * from './drawables/drawable-fill-opacity';
 export * from './drawables/drawable-font-point-size';
 export * from './drawables/drawable-font';
 export * from './drawables/drawable-gravity';
+export * from './drawables/drawable-kerning';
 export * from './drawables/drawable-rectangle';
 export * from './drawables/drawable-round-rectangle';
 export * from './drawables/drawable-text';

--- a/tests/drawables/drawable-kerning.spec.ts
+++ b/tests/drawables/drawable-kerning.spec.ts
@@ -1,0 +1,48 @@
+// Copyright Dirk Lemstra https://github.com/dlemstra/magick-wasm.
+// Licensed under the Apache License, Version 2.0.
+
+import { DrawableText } from "../../src/drawables/drawable-text";
+import { DrawableKerning } from "../../src/drawables/drawable-kerning";
+import { DrawableFillColor } from "../../src/drawables/drawable-fill-color";
+import { DrawableFont } from "../../src/drawables/drawable-font";
+import { DrawableFontPointSize } from "../../src/drawables/drawable-font-point-size";
+import { IMagickImage, MagickImage } from "../../src/magick-image";
+import { MagickColor } from "../../src/magick-color";
+import { MagickColors } from "../../src/magick-colors";
+import { TestFonts } from "../test-fonts";
+
+let image: IMagickImage;
+
+beforeEach(() => {
+    image = MagickImage.create();
+    image.read(MagickColors.White, 140, 147);
+});
+
+afterEach(() => {
+    image.dispose();
+});
+
+describe("DrawableKerning", () => {
+    it("should write text with kerning to the image", () => {
+        image.draw([
+            new DrawableFont(TestFonts.kaushanScriptRegularTtf.name),
+            new DrawableFontPointSize(100),
+            new DrawableKerning(10),
+            new DrawableFillColor(new MagickColor("pink")),
+            new DrawableText(0, 109, "I I"),
+        ]);
+
+        expect(image).toHavePixelWithColor(100, 80, "#ffc0cbff");
+    });
+
+    it("should write text without kerning to the image", () => {
+        image.draw([
+            new DrawableFont(TestFonts.kaushanScriptRegularTtf.name),
+            new DrawableFontPointSize(100),
+            new DrawableFillColor(new MagickColor("pink")),
+            new DrawableText(0, 109, "I I"),
+        ]);
+
+        expect(image).toHavePixelWithColor(100, 80, "#ffffffff");
+    });
+});


### PR DESCRIPTION
Hey, this is more a question than a PR so far.

We are adding text to an image using the following code:
```js
image.draw(
    new DrawableGravity(Gravity.Center),
    new DrawableGravity(Gravity.South),
    new DrawableFont("OurCustomFont"),
    new DrawableFontPointSize(100),
    new DrawableFillColor(new MagickColor("white")),
    new DrawableText(0, 190, formatText(titleText))
);
```

However we have a need to set the text kerning which is not possible.

To work around this we implemented our own `DrawableKerning` as below, but we figured it might make more sense to get it into the library then keeping it to ourselves.

This is just a draft to give you an idea of what we were going for, we assume it might need tests and more work. 

Please let us know if you think this might be a good addition to the lib! 🥳 