### PR TITLE
Add threshold to MagickImage

### DIFF
--- a/src/magick-image.ts
+++ b/src/magick-image.ts
@@ -257,6 +257,8 @@ export interface IMagickImage extends IDisposable {
     statistics(): IStatistics;
     statistics(channels: Channels): IStatistics;
     strip(): void;
+    threshold(percentage: Percentage): void;
+    threshold(percentage: Percentage, channels: Channels): void;
     toString(): string;
     transparent(color: MagickColor): void;
     trim(): void;
@@ -1383,6 +1385,15 @@ export class MagickImage extends NativeInstance implements IMagickImage {
     strip(): void {
         Exception.usePointer(exception => {
             ImageMagick._api._MagickImage_Strip(this._instance, exception);
+        });
+    }
+
+    threshold(percentage: Percentage): void
+    threshold(percentage: Percentage, channels: Channels): void
+    threshold(percentage: Percentage, channelsOrUndefined?: Channels): void {
+        const channels = this.valueOrDefault(channelsOrUndefined, Channels.Undefined);
+        Exception.usePointer(exception => {
+            ImageMagick._api._MagickImage_Threshold(this._instance, percentage.toQuantum(), channels, exception);
         });
     }
 

--- a/tests/magick-image/threshold.spec.ts
+++ b/tests/magick-image/threshold.spec.ts
@@ -1,0 +1,24 @@
+// Copyright Dirk Lemstra https://github.com/dlemstra/magick-wasm.
+// Licensed under the Apache License, Version 2.0.
+
+import { Channels } from '../../src/channels'
+import { ErrorMetric } from '../../src/error-metric'
+import { Percentage } from '../../src/percentage'
+import { TestImages } from '../test-images'
+
+describe('MagickImage#threshold', () => {
+    it('should threshold the image with the correct default values', () => {
+        TestImages.Builtin.logo.use((image) => {
+            image.clone((other) => {
+                image.threshold(new Percentage(80))
+                other.threshold(new Percentage(80), Channels.Undefined)
+
+                const difference = other.compare(
+                    image,
+                    ErrorMetric.RootMeanSquared,
+                )
+                expect(difference).toBe(0)
+            })
+        })
+    })
+})

--- a/tests/magick-image/threshold.spec.ts
+++ b/tests/magick-image/threshold.spec.ts
@@ -1,24 +1,32 @@
 // Copyright Dirk Lemstra https://github.com/dlemstra/magick-wasm.
 // Licensed under the Apache License, Version 2.0.
 
-import { Channels } from '../../src/channels'
-import { ErrorMetric } from '../../src/error-metric'
-import { Percentage } from '../../src/percentage'
-import { TestImages } from '../test-images'
+import { Channels } from '../../src/channels';
+import { ErrorMetric } from '../../src/error-metric';
+import { Percentage } from '../../src/percentage';
+import { TestImages } from '../test-images';
 
 describe('MagickImage#threshold', () => {
     it('should threshold the image with the correct default values', () => {
         TestImages.Builtin.logo.use((image) => {
             image.clone((other) => {
-                image.threshold(new Percentage(80))
-                other.threshold(new Percentage(80), Channels.Undefined)
+                image.threshold(new Percentage(80));
+                other.threshold(new Percentage(80), Channels.Undefined);
 
-                const difference = other.compare(
-                    image,
-                    ErrorMetric.RootMeanSquared,
-                )
-                expect(difference).toBe(0)
-            })
-        })
-    })
-})
+                const difference = other.compare(image, ErrorMetric.RootMeanSquared);
+                expect(difference).toBe(0);
+            });
+        });
+    });
+
+    it('should threshold the image', () => {
+        TestImages.Builtin.logo.use((image) => {
+            image.clone((other) => {
+                image.threshold(new Percentage(80));
+
+                const difference = other.compare(image, ErrorMetric.RootMeanSquared);
+                expect(difference).toBeCloseTo(0.165);
+            });
+        });
+    });
+});


### PR DESCRIPTION
This PR adds the `threshold` method to `MagickImage`.

I based the implementation [on the `Magick.Net` impl](https://github.com/dlemstra/Magick.NET/blob/b00e2a92b3d564f1bc7eb84be20e4f064ea19b75/src/Magick.NET/MagickImage.cs#L6397-L6412).

I also added a test but it doesn't feel very thorough. I'm not sure what to test to validate that the image threshold changes based on the inputs though.