### PR TITLE
Remove build.commonjsOptions.ignore from vite.config.ts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,3 @@
-import { builtinModules } from 'module';
 import { defineConfig } from 'vitest/config';
 import path from 'path';
 
@@ -9,9 +8,6 @@ export default defineConfig({
             entry: 'src/index.ts',
             name: 'magick-wasm',
             fileName: 'index',
-        },
-        commonjsOptions: {
-            ignore: [...builtinModules, 'ws'],
         },
     },
     test: {


### PR DESCRIPTION
Digging into #119 I found that Vite has changed the way it handles the dependencies in question from version 4 and up for both building and consuming.

- For consuming: in version 4 and up you seem to need `ws` in your own project to be able to build when using this library. Maybe version 3 supplied projects with the `ws` that Vite uses itself?
- For building: Vite will now automatically externalize the build in modules, and also seems to have a solution for `ws`.

Taking advantage of these changes by removing `build.commonjsOptions.ignore` seems to resolve both #119 and also remove the need to install `ws` in consuming projects.