### PR TITLE
Add autoGamma, autoLevel and gaussianBlur to MagickImage.

### DIFF
--- a/src/magick-image.ts
+++ b/src/magick-image.ts
@@ -341,6 +341,19 @@ export interface IMagickImage extends IDisposable {
     autoGamma(channels: Channels): void;
 
     /**
+     * Adjusts the levels of a particular image channel by scaling the minimum and maximum
+     * values to the full quantum range.
+     */
+    autoLevel(): void;
+
+    /**
+     * Adjusts the levels of a particular image channel by scaling the minimum and maximum
+     * values to the full quantum range.
+     * @param channels - The channel(s) to level.
+     */
+    autoLevel(channels: Channels): void;
+
+    /**
      * Adjusts an image so that its orientation is suitable for viewing.
      */
     autoOrient(): void;
@@ -1934,6 +1947,14 @@ export class MagickImage extends NativeInstance implements IMagickImage {
         this.useExceptionPointer(exception => {
             const channels = this.valueOrDefault(channelsOrUndefined, Channels.Composite);
             ImageMagick._api._MagickImage_AutoGamma(this._instance, channels, exception);
+        });
+    }
+
+    autoLevel(): void;
+    autoLevel(channelsOrUndefined?: Channels): void {
+        this.useExceptionPointer(exception => {
+            const channels = this.valueOrDefault(channelsOrUndefined, Channels.Undefined);
+            ImageMagick._api._MagickImage_AutoLevel(this._instance, channels, exception);
         });
     }
 

--- a/src/magick-image.ts
+++ b/src/magick-image.ts
@@ -939,6 +939,27 @@ export interface IMagickImage extends IDisposable {
     flop(): void;
 
     /**
+     * Gaussian blur image.
+     * @param radius - The number of neighbor pixels to be included in the convolution.
+     */
+    gaussianBlur(radius: number): void;
+
+    /**
+     * Gaussian blur image.
+     * @param radius - The number of neighbor pixels to be included in the convolution.
+     * @param sigma - The standard deviation of the gaussian bell curve.
+    */
+    gaussianBlur(radius: number, sigma: number): void;
+
+   /**
+    * Gaussian blur image.
+    * @param radius - The number of neighbor pixels to be included in the convolution.
+    * @param sigma - The standard deviation of the gaussian bell curve.
+    * @param sigma - The channel(s) to blur.
+    */
+    gaussianBlur(radius: number, sigma: number, channels: Channels): void;
+
+    /**
      * Returns the value of the artifact with the specified name.
      * @param name - The name of the artifact.
      */
@@ -2430,6 +2451,19 @@ export class MagickImage extends NativeInstance implements IMagickImage {
     flop(): void {
         this.useException(exception => {
             const instance = ImageMagick._api._MagickImage_Flop(this._instance, exception.ptr);
+            this._setInstance(instance, exception);
+        });
+    }
+
+    gaussianBlur(radius: number): void;
+    gaussianBlur(radius: number, sigma: number): void;
+    gaussianBlur(radius: number, sigma: number, channels: Channels): void;
+    gaussianBlur(radius: number, sigmaOrUndefined?: number, channelsOrUndefined?: Channels): void {
+        const sigma = this.valueOrDefault(sigmaOrUndefined, 1.0);
+        const channels = this.valueOrDefault(channelsOrUndefined, Channels.Undefined);
+
+        this.useException(exception => {
+            const instance = ImageMagick._api._MagickImage_GaussianBlur(this._instance, radius, sigma, channels, exception.ptr);
             this._setInstance(instance, exception);
         });
     }

--- a/src/magick-image.ts
+++ b/src/magick-image.ts
@@ -330,6 +330,17 @@ export interface IMagickImage extends IDisposable {
     alpha(value: AlphaOption): void;
 
     /**
+     * Extracts the 'mean' from the image and adjust the image to try make set its gamma appropriately.
+     */
+    autoGamma(): void;
+
+    /**
+     * Extracts the 'mean' from the image and adjust the image to try make set its gamma appropriately.
+     * @param channels - The channel(s) to set the gamma for.
+     */
+    autoGamma(channels: Channels): void;
+
+    /**
      * Adjusts an image so that its orientation is suitable for viewing.
      */
     autoOrient(): void;
@@ -1915,6 +1926,14 @@ export class MagickImage extends NativeInstance implements IMagickImage {
     alpha(value: AlphaOption): void {
         this.useExceptionPointer(exception => {
             ImageMagick._api._MagickImage_SetAlpha(this._instance, value, exception);
+        });
+    }
+
+    autoGamma(): void;
+    autoGamma(channelsOrUndefined?: Channels): void {
+        this.useExceptionPointer(exception => {
+            const channels = this.valueOrDefault(channelsOrUndefined, Channels.Composite);
+            ImageMagick._api._MagickImage_AutoGamma(this._instance, channels, exception);
         });
     }
 

--- a/tests/magick-image/auto-gamma.spec.ts
+++ b/tests/magick-image/auto-gamma.spec.ts
@@ -1,0 +1,36 @@
+// Copyright Dirk Lemstra https://github.com/dlemstra/magick-wasm.
+// Licensed under the Apache License, Version 2.0.
+
+import { Channels } from '@src/enums/channels';
+import { ErrorMetric } from '@src/enums/error-metric';
+import { TestImages } from '@test/test-images';
+
+describe('MagickImage#autoGamma', () => {
+    it('should apply gamma correction to the image', () => {
+        TestImages.Builtin.logo.use(image => {
+            image.autoGamma();
+
+            expect(image).toHavePixelWithColor(496, 429, '#000001ff');
+        });
+    });
+
+    it('should only apply gamma correction to the specified channels', () => {
+        TestImages.Builtin.logo.use(image => {
+            image.autoGamma(Channels.Red);
+
+            expect(image).toHavePixelWithColor(496, 429, '#002d73ff');
+        });
+    });
+
+    it('should use the correct default channels', () => {
+        TestImages.Builtin.logo.use(image => {
+            image.clone(other => {
+                image.autoGamma();
+                other.autoGamma(Channels.Composite);
+
+                const distortion = image.compare(other, ErrorMetric.RootMeanSquared);
+                expect(distortion).toBe(0);
+            })
+        });
+    });
+});

--- a/tests/magick-image/auto-level.spec.ts
+++ b/tests/magick-image/auto-level.spec.ts
@@ -1,0 +1,36 @@
+// Copyright Dirk Lemstra https://github.com/dlemstra/magick-wasm.
+// Licensed under the Apache License, Version 2.0.
+
+import { Channels } from '@src/enums/channels';
+import { ErrorMetric } from '@src/enums/error-metric';
+import { TestImages } from '@test/test-images';
+
+describe('MagickImage#autoLevel', () => {
+    it('should auto level to the image', () => {
+        TestImages.Builtin.rose.use(image => {
+            image.autoLevel();
+
+            expect(image).toHavePixelWithColor(5, 40, '#5b5646ff');
+        });
+    });
+
+    it('should only auto level the specified channels', () => {
+        TestImages.Builtin.rose.use(image => {
+            image.autoLevel(Channels.Red);
+
+            expect(image).toHavePixelWithColor(5, 40, '#516556ff');
+        });
+    });
+
+    it('should use the correct default channels', () => {
+        TestImages.Builtin.rose.use(image => {
+            image.clone(other => {
+                image.autoLevel();
+                other.autoLevel(Channels.Undefined);
+
+                const distortion = image.compare(other, ErrorMetric.RootMeanSquared);
+                expect(distortion).toBe(0);
+            })
+        });
+    });
+});

--- a/tests/magick-image/gaussian-blur.spec.ts
+++ b/tests/magick-image/gaussian-blur.spec.ts
@@ -1,0 +1,40 @@
+// Copyright Dirk Lemstra https://github.com/dlemstra/magick-wasm.
+// Licensed under the Apache License, Version 2.0.
+
+import { Channels } from '@src/enums/channels';
+import { ErrorMetric } from '@src/enums/error-metric';
+import { TestImages } from '@test/test-images';
+
+describe('MagickImage#gaussianBlur', () => {
+    it('should gaussian blur the image', () => {
+        TestImages.Builtin.wizard.use(image => {
+            image.clone(other => {
+                image.gaussianBlur(5.5, 10.2);
+                other.blur(5.5, 10.2);
+
+                const difference = other.compare(image, ErrorMetric.RootMeanSquared);
+                expect(difference).toBeCloseTo(0.000665, 6);
+            })
+        });
+    });
+
+    it('should use the correct default sigma', () => {
+        TestImages.Builtin.wizard.use(image => {
+            image.clone(other => {
+                image.gaussianBlur(4.2);
+                other.gaussianBlur(4.2, 1.0);
+
+                const difference = other.compare(image, ErrorMetric.RootMeanSquared);
+                expect(difference).toEqual(0);
+            });
+        });
+    });
+
+    it('should only blur the specified channels', () => {
+        TestImages.Builtin.wizard.use(image => {
+            image.gaussianBlur(4.2, 1, Channels.Green);
+
+            expect(image).toHavePixelWithColor(120, 200, '#185338ff');
+        });
+    });
+});


### PR DESCRIPTION
`gaussianBlur(radius: number, channels: Channels): void;` was omitted as there is no way to distinguish it from `gaussianBlur(radius: number, sigma: number): void;`