### PR TITLE
Correct channel detection in MagickImage.blur

### DIFF
--- a/src/magick-image.ts
+++ b/src/magick-image.ts
@@ -1935,15 +1935,17 @@ export class MagickImage extends NativeInstance implements IMagickImage {
     blur(channels: Channels): void;
     blur(radius: number, sigma: number): void;
     blur(radius: number, sigma: number, channels: Channels): void;
-    blur(radiusOrChannel?: number | Channels, sigmaOrUndefined?: number, channelsOrUndefined?: Channels): void {
+    blur(radiusOrChannels?: number | Channels, sigmaOrUndefined?: number, channelsOrUndefined?: Channels): void {
         let radius = 0;
         const sigma = this.valueOrDefault(sigmaOrUndefined, 1);
         let channels = this.valueOrDefault(channelsOrUndefined, Channels.Undefined);
 
-        if (typeof radiusOrChannel === 'number')
-            radius = radiusOrChannel;
-        else if (radiusOrChannel !== undefined)
-            channels = radiusOrChannel;
+        if (radiusOrChannels !== undefined) {
+            if (sigmaOrUndefined === undefined)
+                channels = radiusOrChannels;
+            else
+                radius = radiusOrChannels;
+        }
 
         this.useException(exception => {
             const instance = ImageMagick._api._MagickImage_Blur(this._instance, radius, sigma, channels, exception.ptr);

--- a/tests/magick-image/blur.spec.ts
+++ b/tests/magick-image/blur.spec.ts
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 import { Channels } from '@src/enums/channels';
+import { ErrorMetric } from '@src/enums/error-metric';
 import { TestImages } from '@test/test-images';
 
 describe('MagickImage#blur', () => {
@@ -9,6 +10,18 @@ describe('MagickImage#blur', () => {
         TestImages.Builtin.logo.use(image => {
             image.blur(5, 5);
             expect(image).toHavePixelWithColor(222, 60, '#ff6a6aff');
+        });
+    });
+
+    it('should not confuse channels for radius', () => {
+        TestImages.Builtin.logo.use(imageA => {
+            imageA.clone(imageB => {
+                imageA.blur(Channels.Blue);
+                imageB.blur(4, 1);
+
+                const difference = imageB.compare(imageA, ErrorMetric.RootMeanSquared);
+                expect(difference).not.toBe(0);
+            })
         });
     });
 


### PR DESCRIPTION
The `Channels` enum is converted to numerical values on compilation, meaning e.g. `MagickImage.blur(Channels.Blue)` will currently be interpreted as `MagickImage.blur(4, 1)`.

I found this problem during the implementation of `MagickImage.gaussianBlur(radius: number, channels: Channels)`. Unlike there, we don't need to omit it here as we can identify the usage of `MagickImage.blur` by the presence of other arguments. Namely, if a `sigma` value is given then the first argument is a radius, otherwise it is a `Channels` value.