### PR TITLE
Simplify MagickImage.useException(Pointer).

### DIFF
--- a/src/magick-image.ts
+++ b/src/magick-image.ts
@@ -3172,18 +3172,14 @@ export class MagickImage extends NativeInstance implements IMagickImage {
     }
 
     private useException<TReturnType>(func: (exception: Exception) => TReturnType): TReturnType {
-        return Exception.use<TReturnType>(exception => {
-            return func(exception);
-        }, (error: MagickError) => {
+        return Exception.use<TReturnType>(func, error => {
             if (this.onWarning !== undefined)
                 this.onWarning(new WarningEvent(error));
         });
     }
 
     private useExceptionPointer<TReturnType>(func: (exception: number) => TReturnType): TReturnType {
-        return Exception.usePointer<TReturnType>(exception => {
-            return func(exception);
-        }, (error: MagickError) => {
+        return Exception.usePointer<TReturnType>(func, error => {
             if (this.onWarning !== undefined)
                 this.onWarning(new WarningEvent(error));
         });


### PR DESCRIPTION
`func` was unnecessarily wrapped, and the error type `MagicError` can already inferred from the `Exception.use` signature.